### PR TITLE
German translation

### DIFF
--- a/Locale/de_DE/translations.php
+++ b/Locale/de_DE/translations.php
@@ -1,0 +1,15 @@
+<?php
+
+return array(
+    'Sign up' => 'Konto eröffnen',
+    'Unable to create your account' => 'Ihr Konnte konnte nicht erstellt werden',
+    'activate my account' => 'mein Konto aktivieren',
+    'Click on this link to activate your account:' => 'Klicken Sie auf diesen Link, um Ihr Konto zu aktivieren',
+    'Hello %s' => 'Hallo %s',
+    'Email domain restriction for sign up' => 'Eingrenzung der Mail-Domains, die Konten eröffnen dürfen',
+    'Only people with this email address will be allowed to sign up.' => 'Nur Leute mit solchen E-Mail-Adressen dürfen Konten eröffnen.',
+    'Send email verification' => 'Bestätigungsmail senden',
+    'Email verification' => 'Bestätigung der E-Mailadresse',
+    'You are not allowed to register' => 'Sie dürfen kein Konto eröffnen',
+    'Allow people to sign up themselves on Kanboard' => 'Leuten erlauben, selber ein Kanboard-Konto zu eröffnen',
+);


### PR DESCRIPTION
I explicitly used "Konto eröffnen" instead of "anmelden" so that it does not clash with the translation for "log in", which is also "anmelden".